### PR TITLE
Revert "Add retweet etccollective"

### DIFF
--- a/tweets/230622-2041-add-retweet-etccollective.tweet
+++ b/tweets/230622-2041-add-retweet-etccollective.tweet
@@ -1,3 +1,0 @@
----
-retweet: https://twitter.com/ETC_Radio_/status/1671879004364877824
----


### PR DESCRIPTION
Reverts ethereumclassic/tweets-etc_network#271

Due to the tweet failing,  I am reverting this PR, we can re-revert it once we figure out why the tweet is failing.

Most likely to to rate limits (we need to limit how many we push per day).

Please merge this PR as it just removes the failed tweet.